### PR TITLE
Fix "TypeError: unsupported operand type(s) for /: 'str' and 'str'" when loading 10x mtx files

### DIFF
--- a/SEVtras/sc_readwrite.py
+++ b/SEVtras/sc_readwrite.py
@@ -783,7 +783,8 @@ def _read(
             # logg.debug(f"reading sheet {sheet} from file {filename}")
             return read_hdf(filename, sheet)
     # read other file types
-    cachedir = "./cache/"
+    # cachedir = "./cache/"
+    cachedir = Path("./cache/")
     path_cache: Path = cachedir / _slugify(filename).replace(
         f".{ext}", ".h5ad"
     )


### PR DESCRIPTION
When we try to load a 10x mtx file, we get an error message that says "TypeError: unsupported operand type(s) for /: 'str' and 'str'". We think this is because of the _slugify() function, which returns a string. A simple solution for this issue might be to make the cache path a "path" class.

